### PR TITLE
Vanishing token generator and application abductor!

### DIFF
--- a/pynest/nest/server/hl_api_server.py
+++ b/pynest/nest/server/hl_api_server.py
@@ -51,6 +51,7 @@ def get_boolean_environ(env_key, default_value = 'false'):
     return env_value.lower() in ['yes', 'true', 't', '1']
 
 _default_origins = 'localhost,http://localhost,https://localhost'
+DISABLE_AUTHENTICATION = os.environ.get('NEST_DISABLE_AUTHENTICATION', False) == "TRUE"
 CORS_ORIGINS = os.environ.get('NEST_SERVER_CORS_ORIGINS', _default_origins).split(',')
 EXEC_SCRIPT = get_boolean_environ('NEST_SERVER_EXEC_SCRIPT')
 MODULES = os.environ.get('NEST_SERVER_MODULES', 'nest').split(',')
@@ -85,7 +86,7 @@ CORS(app, origins=CORS_ORIGINS, methods=["GET", "POST"])
 
 mpi_comm = None
 
-# Self sufficient, dissapearing authentication function:
+# Self sufficient, dissapearing authentication function
 #
 # * Generates the login token based on salted hash of the ID of this object and the
 #   current time measured by `perf_counter` giving us enough entropy.
@@ -93,7 +94,7 @@ mpi_comm = None
 # * Removes all `nest` accessible references to it, only `app` and `gc` have it, and the
 #   reference this module holds to `app` is deleted before the first request goes through.
 @app.before_request
-def check_token():
+def setup_auth():
     try:
         import inspect
         import gc
@@ -120,22 +121,36 @@ def check_token():
             hasher.update(str(hash(id(self))).encode("utf-8"))
             hasher.update(str(time.perf_counter()).encode("utf-8"))
             self._hash = hasher.hexdigest()
-            print("")
-            print("    Bearer token to login to the NEST server with: ", self._hash)
-            print("")
+            if not DISABLE_AUTHENTICATION:
+                print("")
+                print("    Bearer token to login to the NEST server with: ", self._hash)
+                print("")
+        # Control flow explanation: The first time we hit this line is when below the
+        # function definition we call `setup_auth` without any request existing yet,
+        # so the function exits here after generating and storing the auth hash.
         auth = request.headers["Authorization"]
-        # The line above triggers an error because below we call `check_token` outside of
-        # any request context. The next time, before the app calls the request route
-        # handler, this line will remove the reference this module holds to `app` as well.
-        del globals()["app"]
-        # Use constant-time comparison to avoid timing attacks.
-        if not hmac.compare_digest(auth, f"Bearer {self._hash}"):
+        # We continue here the next time this function is called, which is before the
+        # Flask app handles a request. At that point we also remove this module's
+        # reference to the running app.
+        try:
+            del globals()["app"]
+        except KeyError:
+            pass
+        # Things get simpler here: We just check if the user has given us the right token.
+        if not (
+            DISABLE_AUTHENTICATION
+            # Use constant-time algorithm to campare the strings, to avoid timing attacks.
+            or hmac.compare_digest(auth, f"Bearer {self._hash}")
+        ):
             return ("Unauthorized", 403)
-    except Exception:
+    # DON'T LINT! Intentional bare except clause! Even `KeyboardInterrupt` and
+    # `SystemExit` exceptions should not bypass authentication!
+    except:
         return ("Unauthorized", 403)
 
-check_token()
-del check_token
+
+setup_auth()
+del setup_auth
 
 
 @app.route('/', methods=['GET'])

--- a/pynest/nest/server/hl_api_server.py
+++ b/pynest/nest/server/hl_api_server.py
@@ -86,15 +86,15 @@ CORS(app, origins=CORS_ORIGINS, methods=["GET", "POST"])
 
 mpi_comm = None
 
-# Self sufficient, dissapearing authentication function
-#
-# * Generates the login token based on salted hash of the ID of this object and the
-#   current time measured by `perf_counter` giving us enough entropy.
-# * Stores the token on this function.
-# * Removes all `nest` accessible references to it, only `app` and `gc` have it, and the
-#   reference this module holds to `app` is deleted before the first request goes through.
 @app.before_request
 def setup_auth():
+    """
+    Authentication function that generates and validates the Authorization header with a
+    bearer token.
+
+    Cleans up references to itself and the running `app` from this module, as it may be
+    accessible when the code execution sandbox fails.
+    """
     try:
         import inspect
         import gc
@@ -102,7 +102,7 @@ def setup_auth():
         import hashlib
         import hmac
 
-
+        # Find our reference to the current function in the garbage collector.
         frame = inspect.currentframe()
         code  = frame.f_code
         globs = frame.f_globals
@@ -116,6 +116,8 @@ def setup_auth():
                         if len(funcs) > 1:
                             return ("Unauthorized", 403)
         self = funcs[0]
+        # Use the salted hash (unless `PYTHONHASHSEED` is fixed) of the location of this
+        # function in the Python heap and the current timestamp to create a SHA512 hash.
         if not hasattr(self, "_hash"):
             hasher = hashlib.sha512()
             hasher.update(str(hash(id(self))).encode("utf-8"))
@@ -125,21 +127,22 @@ def setup_auth():
                 print("")
                 print("    Bearer token to login to the NEST server with: ", self._hash)
                 print("")
-        # Control flow explanation: The first time we hit this line is when below the
-        # function definition we call `setup_auth` without any request existing yet,
-        # so the function exits here after generating and storing the auth hash.
+        # The first time we hit the line below is when below the function definition we
+        # call `setup_auth` without any Flask request existing yet, so the function errors
+        # and exits here after generating and storing the auth hash.
         auth = request.headers["Authorization"]
-        # We continue here the next time this function is called, which is before the
-        # Flask app handles a request. At that point we also remove this module's
-        # reference to the running app.
+        # We continue here the next time this function is called, before the Flask app
+        # handles the first request. At that point we also remove this module's reference
+        # to the running app.
         try:
             del globals()["app"]
         except KeyError:
             pass
-        # Things get simpler here: We just check if the user has given us the right token.
+        # Things get more straightforward here: Every time a request is handled, compare
+        # the Authorization header to the hash, with a constant-time algorithm to avoid
+        # timing attacks.
         if not (
             DISABLE_AUTHENTICATION
-            # Use constant-time algorithm to campare the strings, to avoid timing attacks.
             or hmac.compare_digest(auth, f"Bearer {self._hash}")
         ):
             return ("Unauthorized", 403)

--- a/pynest/nest/server/hl_api_server.py
+++ b/pynest/nest/server/hl_api_server.py
@@ -136,7 +136,7 @@ def setup_auth():
         # The first time we hit the line below is when below the function definition we
         # call `setup_auth` without any Flask request existing yet, so the function errors
         # and exits here after generating and storing the auth hash.
-        auth = request.headers["Authorization"]
+        auth = request.headers.get("Authorization", None)
         # We continue here the next time this function is called, before the Flask app
         # handles the first request. At that point we also remove this module's reference
         # to the running app.

--- a/pynest/nest/server/hl_api_server.py
+++ b/pynest/nest/server/hl_api_server.py
@@ -159,7 +159,7 @@ del setup_auth
 @app.route('/', methods=['GET'])
 def index():
     return jsonify({
-        'nest': 1,
+        'nest': nest.__version__,
         'mpi': mpi_comm is not None,
     })
 

--- a/pynest/nest/server/hl_api_server.py
+++ b/pynest/nest/server/hl_api_server.py
@@ -30,11 +30,6 @@ from flask import Flask, request, jsonify
 from flask_cors import CORS
 from flask.logging import default_handler
 
-# This ensures that the logging information shows up in the console running the server,
-# even when Flask's event loop is running.
-root = logging.getLogger()
-root.addHandler(default_handler)
-
 import nest
 
 import RestrictedPython
@@ -46,12 +41,20 @@ from copy import deepcopy
 
 import os
 
-def get_boolean_environ(env_key, default_value = 'false'):
+
+# This ensures that the logging information shows up in the console running the server,
+# even when Flask's event loop is running.
+root = logging.getLogger()
+root.addHandler(default_handler)
+
+
+def get_boolean_environ(env_key, default_value='false'):
     env_value = os.environ.get(env_key, default_value)
     return env_value.lower() in ['yes', 'true', 't', '1']
 
+
 _default_origins = 'localhost,http://localhost,https://localhost'
-DISABLE_AUTHENTICATION = os.environ.get('NEST_DISABLE_AUTHENTICATION', False) == "TRUE"
+DISABLE_AUTHENTICATION = get_boolean_environ('NEST_DISABLE_AUTHENTICATION')
 CORS_ORIGINS = os.environ.get('NEST_SERVER_CORS_ORIGINS', _default_origins).split(',')
 EXEC_SCRIPT = get_boolean_environ('NEST_SERVER_EXEC_SCRIPT')
 MODULES = os.environ.get('NEST_SERVER_MODULES', 'nest').split(',')

--- a/pynest/nest/server/hl_api_server.py
+++ b/pynest/nest/server/hl_api_server.py
@@ -35,10 +35,7 @@ from flask.logging import default_handler
 root = logging.getLogger()
 root.addHandler(default_handler)
 
-from werkzeug.exceptions import abort
-from werkzeug.wrappers import Response
-
-import nest
+# import nest
 
 import RestrictedPython
 import time
@@ -88,11 +85,63 @@ CORS(app, origins=CORS_ORIGINS, methods=["GET", "POST"])
 
 mpi_comm = None
 
+# Self sufficient, dissapearing authentication function:
+#
+# * Generates the login token based on salted hash of the ID of this object and the
+#   current time measured by `perf_counter` giving us enough entropy.
+# * Stores the token on this function.
+# * Removes all `nest` accessible references to it, only `app` and `gc` have it, and the
+#   reference this module holds to `app` is deleted before the first request goes through.
+@app.before_request
+def check_token():
+    try:
+        import inspect
+        import gc
+        import time
+        import hashlib
+        import hmac
+
+
+        frame = inspect.currentframe()
+        code  = frame.f_code
+        globs = frame.f_globals
+        functype = type(lambda: 0)
+        funcs = []
+        for func in gc.get_referrers(code):
+            if type(func) is functype:
+                if getattr(func, "__code__", None) is code:
+                    if getattr(func, "__globals__", None) is globs:
+                        funcs.append(func)
+                        if len(funcs) > 1:
+                            return ("Unauthorized", 403)
+        self = funcs[0]
+        if not hasattr(self, "_hash"):
+            hasher = hashlib.sha512()
+            hasher.update(str(hash(id(self))).encode("utf-8"))
+            hasher.update(str(time.perf_counter()).encode("utf-8"))
+            self._hash = hasher.hexdigest()
+            print("")
+            print("    Bearer token to login to the NEST server with: ", self._hash)
+            print("")
+        auth = request.headers["Authorization"]
+        # The line above triggers an error because below we call `check_token` outside of
+        # any request context. The next time, before the app calls the request route
+        # handler, this line will remove the reference this module holds to `app` as well.
+        del globals()["app"]
+        # Use constant-time comparison to avoid timing attacks.
+        if not hmac.compare_digest(auth, f"Bearer {self._hash}"):
+            return ("Unauthorized", 403)
+    except Exception:
+        return ("Unauthorized", 403)
+
+check_token()
+del check_token
+
 
 @app.route('/', methods=['GET'])
 def index():
     return jsonify({
-        'nest': nest.__version__,
+        'nest': 1,
         'mpi': mpi_comm is not None,
     })
 
@@ -128,7 +177,7 @@ def do_exec(args, kwargs):
     except Exception as e:
         for line in traceback.format_exception(*sys.exc_info()):
             print(line, flush=True)
-        abort(Response(str(e), EXCEPTION_ERROR_STATUS))
+        flask.abort(EXCEPTION_ERROR_STATUS, str(e))
 
 
 def log(call_name, msg):
@@ -202,7 +251,7 @@ def route_exec():
 # RESTful API
 # --------------------------
 
-nest_calls = dir(nest)
+nest_calls = []
 nest_calls = list(filter(lambda x: not x.startswith('_'), nest_calls))
 nest_calls.sort()
 

--- a/pynest/nest/server/hl_api_server.py
+++ b/pynest/nest/server/hl_api_server.py
@@ -265,10 +265,10 @@ def route_exec():
         response = do_call('exec', args, kwargs)
         return jsonify(response)
     else:
-        abort(Response(
+        flask.abort(
+            403,
             'The route `/exec` has been disabled. Please contact the server administrator.',
-            403
-        ))
+        )
 
 
 # --------------------------
@@ -371,7 +371,7 @@ def get_or_error(func):
         except Exception as e:
             for line in traceback.format_exception(*sys.exc_info()):
                 print(line, flush=True)
-            abort(Response(str(e), EXCEPTION_ERROR_STATUS))
+            flask.abort(EXCEPTION_ERROR_STATUS, str(e))
     return func_wrapper
 
 

--- a/pynest/nest/server/hl_api_server.py
+++ b/pynest/nest/server/hl_api_server.py
@@ -35,7 +35,7 @@ from flask.logging import default_handler
 root = logging.getLogger()
 root.addHandler(default_handler)
 
-# import nest
+import nest
 
 import RestrictedPython
 import time
@@ -266,7 +266,7 @@ def route_exec():
 # RESTful API
 # --------------------------
 
-nest_calls = []
+nest_calls = dir(nest)
 nest_calls = list(filter(lambda x: not x.startswith('_'), nest_calls))
 nest_calls.sort()
 

--- a/pynest/nest/server/hl_api_server.py
+++ b/pynest/nest/server/hl_api_server.py
@@ -21,12 +21,19 @@
 
 import importlib
 import inspect
+import logging
 import io
 import sys
 
 import flask
 from flask import Flask, request, jsonify
 from flask_cors import CORS, cross_origin
+from flask.logging import default_handler
+
+# This ensures that the logging information shows up in the console running the server,
+# even when Flask's event loop is running.
+root = logging.getLogger()
+root.addHandler(default_handler)
 
 from werkzeug.exceptions import abort
 from werkzeug.wrappers import Response

--- a/pynest/nest/server/hl_api_server.py
+++ b/pynest/nest/server/hl_api_server.py
@@ -27,7 +27,7 @@ import sys
 
 import flask
 from flask import Flask, request, jsonify
-from flask_cors import CORS, cross_origin
+from flask_cors import CORS
 from flask.logging import default_handler
 
 # This ensures that the logging information shows up in the console running the server,
@@ -53,7 +53,8 @@ def get_boolean_environ(env_key, default_value = 'false'):
     env_value = os.environ.get(env_key, default_value)
     return env_value.lower() in ['yes', 'true', 't', '1']
 
-CORS_ORIGINS = os.environ.get('NEST_SERVER_CORS_ORIGINS', 'http://localhost:8000').split(',')
+_default_origins = 'localhost,http://localhost,https://localhost'
+CORS_ORIGINS = os.environ.get('NEST_SERVER_CORS_ORIGINS', _default_origins).split(',')
 EXEC_SCRIPT = get_boolean_environ('NEST_SERVER_EXEC_SCRIPT')
 MODULES = os.environ.get('NEST_SERVER_MODULES', 'nest').split(',')
 RESTRICTION_OFF = get_boolean_environ('NEST_SERVER_RESTRICTION_OFF')
@@ -81,27 +82,14 @@ __all__ = [
 ]
 
 app = Flask(__name__)
-CORS(app, CORS_ORIGINS=CORS_ORIGINS)
+# Inform client-side user agents that they should not attempt to call our server from any
+# non-whitelisted domain.
+CORS(app, origins=CORS_ORIGINS, methods=["GET", "POST"])
 
 mpi_comm = None
 
 
-@app.after_request
-def cors_origin(response):
-    # https://kurianbenoy.com/2021-07-04-CORS/
-    response.headers["Access-Control-Allow-Origin"] = "null"
-    request_origin = request.headers['Origin']
-    if len(CORS_ORIGINS) == 0 or "*" in CORS_ORIGINS:
-        response.headers["Access-Control-Allow-Origin"] = "*"
-    else:
-        for allowed_origin in CORS_ORIGINS:
-            if allowed_origin in request_origin:
-                response.headers["Access-Control-Allow-Origin"] = allowed_origin
-    return response
-
-
 @app.route('/', methods=['GET'])
-@cross_origin()
 def index():
     return jsonify({
         'nest': nest.__version__,
@@ -195,7 +183,6 @@ def do_call(call_name, args=[], kwargs={}):
 
 
 @app.route('/exec', methods=['GET', 'POST'])
-@cross_origin()
 def route_exec():
     """ Route to execute script in Python.
     """
@@ -229,7 +216,6 @@ def route_api():
 
 
 @app.route('/api/<call>', methods=['GET', 'POST'])
-@cross_origin()
 def route_api_call(call):
     """ Route to call function in NEST.
     """

--- a/pynest/nest/server/hl_api_server.py
+++ b/pynest/nest/server/hl_api_server.py
@@ -208,7 +208,6 @@ nest_calls.sort()
 
 
 @app.route('/api', methods=['GET'])
-@cross_origin()
 def route_api():
     """ Route to list call functions in NEST.
     """

--- a/pynest/nest/server/hl_api_server.py
+++ b/pynest/nest/server/hl_api_server.py
@@ -89,6 +89,7 @@ CORS(app, origins=CORS_ORIGINS, methods=["GET", "POST"])
 
 mpi_comm = None
 
+
 @app.before_request
 def setup_auth():
     """
@@ -99,15 +100,17 @@ def setup_auth():
     accessible when the code execution sandbox fails.
     """
     try:
-        import inspect
-        import gc
-        import time
-        import hashlib
-        import hmac
+        # Import the modules inside of the auth function, so that if they fail the auth
+        # returns a forbidden error.
+        import inspect  # noqa
+        import gc  # noqa
+        import time  # noqa
+        import hashlib  # noqa
+        import hmac  # noqa
 
         # Find our reference to the current function in the garbage collector.
         frame = inspect.currentframe()
-        code  = frame.f_code
+        code = frame.f_code
         globs = frame.f_globals
         functype = type(lambda: 0)
         funcs = []
@@ -151,7 +154,7 @@ def setup_auth():
             return ("Unauthorized", 403)
     # DON'T LINT! Intentional bare except clause! Even `KeyboardInterrupt` and
     # `SystemExit` exceptions should not bypass authentication!
-    except:
+    except:  # noqa
         return ("Unauthorized", 403)
 
 
@@ -300,8 +303,8 @@ def route_api_call(call):
 # ----------------------
 
 class Capturing(list):
-    """ Monitor stdout contents i.e. print.
-    """
+    """ Monitor stdout contents i.e. print. """
+
     def __enter__(self):
         self._stdout = sys.stdout
         sys.stdout = self._stringio = io.StringIO()


### PR DESCRIPTION
Created toggleable authenticator that verifies `Bearer <token>` has been added to the authorization headers. The comments should sufficiently explain what is going on. I tried to make sure that no references to the authenticator exist, but we should probably scrub the `hl_api_server` further when we have more time, making everything in it underscore prefixed, and simply remove any references we don't need once `app.run` is called.